### PR TITLE
Maintain session ID.

### DIFF
--- a/src/agent/controllers/intent.js
+++ b/src/agent/controllers/intent.js
@@ -3,9 +3,12 @@ const dialogflow = new require('../helpers/dialogflow');
 const router = express.Router();
 
 router.post('/detect', function (req, res) {
-    dialogflow.connect();
-    let response = dialogflow.detectIntent(req.body.agent, req.body.text, req.body.language);
-    response.then((data) => res.send(data));
+    const creds = dialogflow.connect(req.body.session, req.body.agent);
+    let response = dialogflow.detectIntent(creds, req.body.text, req.body.language);
+    response.then((data) => {
+        data.session = creds.session;
+        res.send(data);
+    });
     response.catch((error) => res.send({'errors': ['Request could not be processed.']}));
 });
 


### PR DESCRIPTION
# Summary

Re-use same session ID when possible. Up until now, the API would create a new session with each request.